### PR TITLE
Imperial Council Law Fix

### DIFF
--- a/common/job_titles/00_job_titles.txt
+++ b/common/job_titles/00_job_titles.txt
@@ -64,7 +64,7 @@ job_chancellor = {
 		if = {
 			limit = {
 				OR = {
-					has_global_flag = ec_imperial_council_restricted
+					# has_global_flag = ec_imperial_council_restricted
 					has_global_flag = ec_imperial_council_confirmed
 				}
 				FROM = {
@@ -209,7 +209,7 @@ job_marshal = {
 		if = {
 			limit = {
 				OR = {
-					has_global_flag = ec_imperial_council_restricted
+					# has_global_flag = ec_imperial_council_restricted
 					has_global_flag = ec_imperial_council_confirmed
 				}
 				FROM = {
@@ -411,7 +411,7 @@ job_treasurer = {
 		if = {
 			limit = {
 				OR = {
-					has_global_flag = ec_imperial_council_restricted
+					# has_global_flag = ec_imperial_council_restricted
 					has_global_flag = ec_imperial_council_confirmed
 				}
 				FROM = {
@@ -558,7 +558,7 @@ job_spymaster = {
 		if = {
 			limit = {
 				OR = {
-					has_global_flag = ec_imperial_council_restricted
+					# has_global_flag = ec_imperial_council_restricted
 					has_global_flag = ec_imperial_council_confirmed
 				}
 				FROM = {
@@ -672,7 +672,7 @@ job_spiritual = {
 		if = {
 			limit = {
 				OR = {
-					has_global_flag = ec_imperial_council_restricted
+					# has_global_flag = ec_imperial_council_restricted
 					has_global_flag = ec_imperial_council_confirmed
 				}
 				FROM = {

--- a/common/scripted_effects/ek_elder_council_effects.txt
+++ b/common/scripted_effects/ek_elder_council_effects.txt
@@ -2420,17 +2420,7 @@ ec_council_imperial_council = {
 			ec_imperial_council_none = yes
 		}
 		custom_tooltip = {
-			text = implement_policy.imperial_council.confirmed
-			set_global_flag = ec_imperial_council_confirmed
-		}
-	}
-	else_if = {
-		limit = {
-			has_global_flag = ec_imperial_council_confirmed
-		}
-		custom_tooltip = {
 			text = implement_policy.imperial_council.restricted
-			clr_global_flag = ec_imperial_council_confirmed
 			set_global_flag = ec_imperial_council_restricted
 		}
 	}
@@ -2442,18 +2432,8 @@ ec_imperial_imperial_council = {
 			has_global_flag = ec_imperial_council_restricted
 		}
 		custom_tooltip = {
-			text = implement_policy.imperial_council.confirmed
-			clr_global_flag = ec_imperial_council_restricted
-			set_global_flag = ec_imperial_council_confirmed
-		}
-	}
-	else_if = {
-		limit = {
-			has_global_flag = ec_imperial_council_confirmed
-		}
-		custom_tooltip = {
 			text = implement_policy.imperial_council.none
-			clr_global_flag = ec_imperial_council_confirmed
+			clr_global_flag = ec_imperial_council_restricted
 		}
 	}
 }

--- a/decisions/ek_elder_council_decisions.txt
+++ b/decisions/ek_elder_council_decisions.txt
@@ -2335,7 +2335,7 @@ decisions = {
 		potential = {
 			ec_can_propose_laws = yes
 			NOT = {
-				has_global_flag = ec_imperial_legislature_de_facto
+				has_global_flag = ec_imperial_council_restricted
 			}
 		}
 
@@ -2450,7 +2450,7 @@ decisions = {
 
 		potential = {
 			ec_can_propose_laws = yes
-			ec_imperial_legislature_none = no
+			ec_imperial_council_none = no
 		}
 
 		allow = {

--- a/events/ek_elder_council.txt
+++ b/events/ek_elder_council.txt
@@ -13284,7 +13284,7 @@ character_event = {
 	option = {
 		name = eldercouncil.very_well
 		ec_show_votes = yes
-		ec_tooltip_imperial_legislature = yes
+		ec_tooltip_imperial_council = yes
 	}
 }
 
@@ -13316,7 +13316,7 @@ character_event = {
 	option = {
 		name = eldercouncil.very_well
 		ec_show_votes = yes
-		ec_tooltip_imperial_legislature = yes
+		ec_tooltip_imperial_council = yes
 	}
 }
 

--- a/localisation/000_ek_elder_council.csv
+++ b/localisation/000_ek_elder_council.csv
@@ -1025,7 +1025,7 @@ eldercouncil.736.failed;The Council has voted against increasing its power to co
 eldercouncil.736.tied;The Council has not reached a increasing its power to control the Ruby Throne's private council. [GetECVoteTally] As High Chancellor, it falls to you to break the tie.;;;;;;;;;;;;;x
 eldercouncil.737.passed;The Elder Council has voted in favour of increasing its power to control the Ruby Throne's private council. [GetECVoteTally];;;;;;;;;;;;;x
 eldercouncil.737.tied;The Elder Council has voted in favour of increasing its power to control the Ruby Throne's private council. [GetECVoteTally];;;;;;;;;;;;;x
-eldercouncil.738.failed;The Elder Council has voted in favour of increasing its power to control the Ruby Throne's private council. [GetECVoteTally];;;;;;;;;;;;;x
+eldercouncil.738.failed;The Elder Council has voted against of increasing its power to control the Ruby Throne's private council. [GetECVoteTally];;;;;;;;;;;;;x
 eldercouncil.738.tied;The Elder Council has voted against of increasing its power to control the Ruby Throne's private council. [GetECVoteTally];;;;;;;;;;;;;x
 eldercouncil.739.desc;[From.GetTitledName] has vetoed the proceedings of the Elder Council in the middle of its debate concerning giving the Elder Council more power over the Ruby Throne's personal council, preventing the motion from coming into law.;;;;;;;;;;;;;x
 ### Deregulate Personal Council


### PR DESCRIPTION
- Removed Elder Council approval of personal council members due to it being prone to breaking
- Corrected event text surrounding the council appointment vote chain