### PR TITLE
Decision to Refute a Claim

### DIFF
--- a/decisions/ek_plot_decisions.txt
+++ b/decisions/ek_plot_decisions.txt
@@ -1,0 +1,38 @@
+plot_decisions = {
+
+	plot_refute_claim_decision = {
+		only_playable = yes
+		is_high_prio = yes
+		ai_check_interval = 12
+		
+		potential = {
+			always = yes # Disabled
+			is_playable = yes
+			has_plot = plot_refute_claim
+			NOT = { has_character_flag = plot_refute_claim_decision_taken }
+		}
+		allow = {
+			plot_power = 1.0
+			num_of_plot_backers = 1
+		}
+		effect = {
+			plot_target_char = {
+				letter_event = { id = sorplots.0 days = 3 tooltip = "EVTTOOLTIP8000" }
+			}
+			hidden_tooltip = {
+				set_character_flag = plot_refute_claim_decision_taken
+				activate_plot = yes
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { plot_power = 1.1 }
+			}
+		}
+	}
+}

--- a/decisions/ek_plot_decisions.txt
+++ b/decisions/ek_plot_decisions.txt
@@ -10,6 +10,7 @@ plot_decisions = {
 			is_playable = yes
 			has_plot = plot_refute_claim
 			NOT = { has_character_flag = plot_refute_claim_decision_taken }
+			has_submenu_open = no
 		}
 		allow = {
 			plot_power = 1.0

--- a/decisions/ek_plot_decisions.txt
+++ b/decisions/ek_plot_decisions.txt
@@ -9,19 +9,27 @@ plot_decisions = {
 			always = yes # Disabled
 			is_playable = yes
 			has_plot = plot_refute_claim
-			NOT = { has_character_flag = plot_refute_claim_decision_taken }
 			has_submenu_open = no
 		}
 		allow = {
 			plot_power = 1.0
 			num_of_plot_backers = 1
+			custom_tooltip = {
+				text = refute_claim_cooldown_tooltip
+				hidden_tooltip = {
+					OR = {
+						NOT = { has_character_flag = refute_claim_cooldown }
+						had_character_flag = { flag = refute_claim_cooldown days = 365 }
+					}
+				}
+			}
 		}
 		effect = {
 			plot_target_char = {
 				letter_event = { id = sorplots.0 days = 3 tooltip = "EVTTOOLTIP8000" }
 			}
 			hidden_tooltip = {
-				set_character_flag = plot_refute_claim_decision_taken
+				set_character_flag = refute_claim_cooldown
 				activate_plot = yes
 			}
 		}

--- a/events/ek_refuteclaim_events.txt
+++ b/events/ek_refuteclaim_events.txt
@@ -10,7 +10,7 @@ letter_event = {
 	option = {
 		name = Accept_Demand_opt
 		ai_chance = {
-			factor = 10
+			factor = 5
 			modifier = {
 				factor = 3
 				trait = craven
@@ -98,11 +98,13 @@ letter_event = {
 	}
 	option = {
 		trigger = {
-			NOT = { has_character_flag = Depressed_Dead_Familar }
-			and = {
+			NOT = { 
+				has_character_flag = Depressed_Dead_Familar 
+				AND = {
 				prisoner = yes 
 				host = { character = FROM  }
-			}			
+				}	
+			}		
 		}
 		name = refute_Claim_Refuse_Demand_opt
 		ai_chance = {
@@ -137,7 +139,7 @@ letter_event = {
 			}
 			modifier = {
 				factor = 0.0
-				and = {
+				AND = {
 					prisoner = yes 
 					host = { character = FROM  }
 				}

--- a/events/ek_refuteclaim_events.txt
+++ b/events/ek_refuteclaim_events.txt
@@ -164,6 +164,7 @@ letter_event = {
 		prestige = 50		
 		hidden_tooltip = {
 			set_character_flag = plot_refute_claim_success
+			clr_character_flag = refute_claim_decision_taken
 		}
 	}
 }

--- a/localisation/000_Sora_RefuteClaim.csv
+++ b/localisation/000_Sora_RefuteClaim.csv
@@ -1,9 +1,10 @@
 plot_refute_claim_desc;Force this individual to relinquish a claim to one of your titles.;;;;;;;;;;;;;x
 plot_refute_claim_short;Refute Claim;;;;;;;;;;;;;x
 plot_refute_claim_title;Refute Claim;;;;;;;;;;;;;x
-refute_Claim_Failed;Your plot to refute a claim failed;;;;;;;;;;;;;x
-refute_Claim_Stop_Plot;Stop trying to refute the claim;;;;;;;;;;;;;x
-refute_Claim_Continue_Plot;Continue trying to refute the claim.;;;;;;;;;;;;;x
+refute_claim_cooldown_tooltip;You can only ask someone to abandon a claim once per year.;;;;;;;;;;;;;x
+refute_Claim_Failed;Despite your fair request, [From.GetTitledName] has refused to abandon [From.GetHerHis] claim on your title.;;;;;;;;;;;;;x
+refute_Claim_Stop_Plot;Perhaps my efforts are better placed elsewhere...;;;;;;;;;;;;;x
+refute_Claim_Continue_Plot;[From.GetSheHe] just needs more time to see reason.;;;;;;;;;;;;;x
 refute_Claim_Success_desc;Your plot to refute a claim succeeded.;;;;;;;;;;;;;x
 refute_Claim_Accept_desc;I have no choice but to accept your demands and relinquish my claim.;;;;;;;;;;;;;x
 refute_Claim_Success_opt;Great.;;;;;;;;;;;;;x

--- a/localisation/000_Sora_RefuteClaim.csv
+++ b/localisation/000_Sora_RefuteClaim.csv
@@ -4,7 +4,7 @@ plot_refute_claim_title;Refute Claim;;;;;;;;;;;;;x
 refute_claim_cooldown_tooltip;You can only ask someone to abandon a claim once per year.;;;;;;;;;;;;;x
 refute_Claim_Failed;Despite your fair request, [From.GetTitledName] has refused to abandon [From.GetHerHis] claim on your title.;;;;;;;;;;;;;x
 refute_Claim_Stop_Plot;Perhaps my efforts are better placed elsewhere...;;;;;;;;;;;;;x
-refute_Claim_Continue_Plot;[From.GetSheHe] just needs more time to see reason.;;;;;;;;;;;;;x
+refute_Claim_Continue_Plot;[From.GetSheHeCap] just needs time to see reason.;;;;;;;;;;;;;x
 refute_Claim_Success_desc;Your plot to refute a claim succeeded.;;;;;;;;;;;;;x
 refute_Claim_Accept_desc;I have no choice but to accept your demands and relinquish my claim.;;;;;;;;;;;;;x
 refute_Claim_Success_opt;Great.;;;;;;;;;;;;;x


### PR DESCRIPTION
Implementation of a decision to execute the previously broken Refute Claim plot, based on the vanilla Revoke Title plot decision.

The decision itself is simple; it requires 100% plot power, at least one backer, and cannot be taken more than once per year. This reflects the difficulty of obtaining evidence that someone else's claim is illegitimate, and prevents the player from simply spamming it for a prestige loss until the AI relents. I also lowered the likelihood of the AI choosing to accept the demand outright with no other modifiers - nobody would just willingly give up a claim to their birthright for no good reason. The rest of the weighting is unchanged.

I added a new file within the decisions folder to fit the existing structure and potentially allow additional plot decisions to be implemented alongside it. In addition, I slightly edited the localization file for the events to better fit vanilla's writing style. The rest of the relevant code has been left untouched to allow other parts of the event chain to be reimplemented in the future, should anyone choose to do so.
